### PR TITLE
Update free-programming-books-ja.md / add textbook from Kyoto Univ.

### DIFF
--- a/free-programming-books-ja.md
+++ b/free-programming-books-ja.md
@@ -539,6 +539,7 @@
 * [The Programming Historian](https://sites.google.com/site/theprogramminghistorianja/) - William J. Turkel, Alan MacEachern, @moroshigeki(翻訳), @historyanddigi(翻訳), @Say\_no(翻訳), @knagasaki(翻訳), @mak\_goto(翻訳)
 * [Think Python：コンピュータサイエンティストのように考えてみよう](http://www.cauldron.sakura.ne.jp/thinkpython/thinkpython/ThinkPython.pdf) - Allen Downey, 相川 利樹（翻訳）(PDF)
 * [お気楽 Python プログラミング入門](http://www.nct9.ne.jp/m_hiroi/light/) - 広井誠
+* [プログラミング演習 Python 2019](http://hdl.handle.net/2433/245698) - 喜多一 (PDF)
 * [みんなのPython Webアプリ編](https://coreblog.org/ats/stuff/minpy_web/) - 柴田淳
 * [機械学習の Python との出会い (Machine Learning Meets Python)](http://www.kamishima.net/mlmpyja/) - 神嶌敏弘 [PDF](http://www.kamishima.net/archive/mlmpyja.pdf), [EPUB](http://www.kamishima.net/archive/mlmpyja.epub)
 


### PR DESCRIPTION
The textbook written for the course on python is freely licensed ([CC-BY-NC-ND](https://creativecommons.org/licenses/by-nc-nd/4.0/)), so it seems worth being added.

## What does this PR do?
Add Resource

## For resources
### Description 

Add the textbook of Python used in Kyoto University.

### Why is this valuable (or not)

This is written for the one of the highest level of education in Japan, and in addition, it is freely licensed.

### How do we know it's really free?

The license description is found on the book itself, and it says it is licensed under CC-BY-NC-CD.

### For book lists, is it a book?

Yes.

### Checklist:
- [x] Not a duplicate
- [x] Included author(s) if appropriate
- [x] Lists are in alphabetical order
- [x] Needed indications added (PDF, access notes, under construction)
